### PR TITLE
Fix bug of drag cannot work when adding div content in title

### DIFF
--- a/jkanban.js
+++ b/jkanban.js
@@ -96,8 +96,7 @@ var dragula = require('dragula');
                 //Init Drag Item
                 self.drake = self.dragula(self.boardContainer, {
                     moves: function (el, source, handle, sibling) {
-                        if (!self.options.dragItems) return false;
-                        return (handle.classList.contains('kanban-items') && !handle.classList.contains('not-draggable'));
+                        return !!self.options.dragItems;
                     },
                     revertOnSpill: true
                 })


### PR DESCRIPTION
The thing is, if add html div content as title property, and then drag, then may get inner div as current context handle rather than desired 'kanban-item'