### PR TITLE
Fix console error with class 'not-draggable'

### DIFF
--- a/dist/jkanban.js
+++ b/dist/jkanban.js
@@ -967,6 +967,9 @@ function dragula (initialContainers, options) {
     if (isContainer(item)) {
       return; // don't drag container itself
     }
+    if(item.classList.contains('not-draggable')) {
+      return; // don't drag elements with class 'not-draggable'
+    }
     var handle = item;
     while (getParent(item) && isContainer(getParent(item)) === false) {
       if (o.invalid(item, handle)) {


### PR DESCRIPTION
When the class 'not-draggable' is used, the element cannot be dragged in the kanban, this is working, but an error appears in the console:

Uncaught TypeError: can't access property "getBoundingClientRect", el is null jkanban.js:1344:28

That extra verification stops the plugin execution, and therefore, the moment of when the error occurs.