### PR TITLE
Fix bug where classes with empty spaces break boards render

### DIFF
--- a/jkanban.js
+++ b/jkanban.js
@@ -279,7 +279,9 @@ var dragula = require("dragula");
           var allClasses = board.class.split(",");
         else allClasses = [];
         headerBoard.classList.add("kanban-board-header");
-        allClasses.map(function(value) {
+        allClasses.map(function (value) {
+          // Remove empty spaces
+          value = value.replace(/^[ ]+/g, "");
           headerBoard.classList.add(value);
         });
         headerBoard.innerHTML =


### PR DESCRIPTION
When trying to replicate bug #89 https://github.com/riktar/jkanban/issues/89, found the another bug where if you put spaces beetween commas on the board object it would break the rendring of the boards.

Obs: Couldn't replicate original bug#89.